### PR TITLE
Update NSObject+SVMaybe.m

### DIFF
--- a/SVMaybe/NSObject+SVMaybe.m
+++ b/SVMaybe/NSObject+SVMaybe.m
@@ -28,7 +28,7 @@ static NSMapTable *nothingDefinitions;
 __attribute__((constructor))
 static void initialize_nothingDefinitions()
 {
-    nothingDefinitions = [[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableWeakMemory capacity:0];
+    nothingDefinitions = [[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableStrongMemory];
 }
 
 @implementation NSObject (SVMaybe)


### PR DESCRIPTION
NSMapTableStrongMemory for valueOptions because with ARC "nothingDefinitions" becomes empty.
